### PR TITLE
Use current signing certificate for PSWinReporting 1.8.1.7

### DIFF
--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -127,7 +127,7 @@ Build-Module -ModuleName 'PSWinReporting' {
     # when creating PSD1 use special style without comments and with only required parameters
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A'
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 


### PR DESCRIPTION
## Summary

- replace the expired legacy code-signing certificate thumbprint with the current EVOTEC code-signing certificate
- keep the final PSWinReporting 1.8.1.7 compatibility release reproducible from its release branch

## Scope

This changes release configuration only. The module source, manifest version, dependencies, exports, and runtime behavior are unchanged.

## Release order

Merge this correction before publishing PSWinReporting 1.8.1.7 to PowerShell Gallery and the EventViewerX GitHub release feed.
