### PR TITLE
Use current signing certificate for PSWinReportingV2 2.0.24

### DIFF
--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -108,7 +108,7 @@ Build-Module -ModuleName 'PSWinReportingV2' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'DefaultPSM1' -EnableFormatting -Sort None
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
-    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A'
 
     New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' -ModulesPath 'Modules' -AddRequiredModules -RequiredModulesSource Download -RequiredModulesRepository 'PSGallery'
     New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -IncludeTagName


### PR DESCRIPTION
## Summary

- replace the expired legacy code-signing certificate thumbprint with the current EVOTEC code-signing certificate
- keep the final PSWinReportingV2 2.0.24 compatibility release reproducible from its release branch

## Scope

This changes release configuration only. The module source, manifest version, dependencies, exports, and runtime behavior are unchanged.

## Release order

Merge this correction before publishing PSWinReportingV2 2.0.24 to PowerShell Gallery and the EventViewerX GitHub release feed.
