### PR TITLE
fix(release): 🐛 Allow final v1 Gallery publication

### DIFF
--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -134,7 +134,9 @@ Build-Module -ModuleName 'PSWinReporting' {
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -AddRequiredModules -RequiredModulesSource Download -RequiredModulesRepository 'PSGallery'
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -ArtefactName '<ModuleName>.v<ModuleVersion>.zip'
 
-    New-ConfigurationPublish -Type PowerShellGallery -ApiKey $PowerShellGalleryApiKey -Enabled:$false
+    # The Gallery contains the historical 2.0.0-preview1 package. This final v1
+    # maintenance release is intentionally lower in semantic version order.
+    New-ConfigurationPublish -Type PowerShellGallery -ApiKey $PowerShellGalleryApiKey -Enabled:$false -Force
     New-ConfigurationPublish -Type GitHub -ApiKey $GitHubApiKey -UserName 'EvotecIT' -RepositoryName 'EventViewerX' -Enabled:$false -GenerateReleaseNotes -OverwriteTagName '{ModuleName}-v{ModuleVersionWithPreRelease}'
 
     New-ConfigurationGate -Mode $RunMode


### PR DESCRIPTION
## Summary

- declares the supported PowerForge force-publish option for the final PSWinReporting v1 maintenance release
- documents why version 1.8.1.7 is intentionally below the historical 2.0.0-preview1 Gallery package
- keeps signing, packaging, credential, duplicate-version, and destination validation unchanged

## Release ordering

This must merge into `PSWinReporting` before publishing PSWinReporting 1.8.1.7 from the repository wrapper. PSWinReportingV2 2.0.24 is independent.