### PR TITLE
Make performance evidence useful to EventViewerX readers

### DIFF
--- a/Benchmarks/EventLogParsing/Invoke-EventLogParsingBenchmark.ps1
+++ b/Benchmarks/EventLogParsing/Invoke-EventLogParsingBenchmark.ps1
@@ -82,7 +82,7 @@ $repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).
 $hostProject = Join-Path $PSScriptRoot 'EventLogParsing.BenchmarkHost\EventLogParsing.BenchmarkHost.csproj'
 $specPath = Join-Path $PSScriptRoot 'event-log-parsing.benchmark.ps1'
 
-Import-Module PSPublishModule -MinimumVersion 3.0.76 -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.134 -ErrorAction Stop
 
 if ([bool] $EvtxECmdPath -ne [bool] $EvtxMapsPath) {
     throw 'EvtxECmdPath and EvtxMapsPath must be supplied together.'
@@ -272,7 +272,10 @@ if (-not $Plan) {
         throw "The benchmark completed with $($failedSamples.Count) failed sample(s):`n$($failureSummary -join "`n")"
     }
 
-    $readmePath = Join-Path $repositoryRoot 'README.md'
+    $readmePath = Join-Path $PSScriptRoot 'README.md'
+    if ($ReadmeTable -in 'Scale', 'ColdStart', 'Reporting') {
+        $readmePath = Join-Path $repositoryRoot 'README.md'
+    }
     if ($ReadmeTable -eq 'Common') {
         Update-BenchmarkDocument `
             -Path $readmePath `

--- a/Benchmarks/EventLogParsing/Invoke-EventLogParsingBenchmark.ps1
+++ b/Benchmarks/EventLogParsing/Invoke-EventLogParsingBenchmark.ps1
@@ -71,7 +71,7 @@ param(
     [ValidateRange(1, [int]::MaxValue)]
     [int] $IterationCount = 1,
 
-    [ValidateSet('None', 'Common', 'Scale', 'ColdStart', 'Reporting', 'ExactOutput', 'NativeOutput', 'EvtxNative')]
+    [ValidateSet('None', 'Common', 'Scale', 'ColdStart', 'Reporting', 'ExactOutput', 'NativeOutput')]
     [string] $ReadmeTable = 'None',
 
     [switch] $Plan
@@ -134,17 +134,6 @@ if ($ReadmeTable -notin 'None', 'ColdStart', 'Reporting') {
             'Large-Native-Output-Xml'
         )
         $Engine = 'EventViewerXExport', 'EvtxECmd'
-    } elseif ($ReadmeTable -eq 'EvtxNative') {
-        if (-not $EvtxECmdPath -or -not $EvtxMapsPath) {
-            throw 'ReadmeTable EvtxNative requires EvtxECmdPath and EvtxMapsPath.'
-        }
-        $Case = @(
-            'Large-Evtx-NativeParse'
-            'Large-Evtx-ForensicCsv'
-            'Large-Evtx-FullJson'
-            'Large-Evtx-Xml'
-        )
-        $Engine = 'EvtxECmd'
     }
 }
 if ($ReadmeTable -eq 'Reporting') {
@@ -315,13 +304,6 @@ if (-not $Plan) {
         Update-BenchmarkDocument `
             -Path $readmePath `
             -BlockId 'event-log-native-output-benchmark' `
-            -ComparisonPath $benchmarkResult.Artifacts['comparison.json'] `
-            -Renderer ComparisonTable `
-            -Confirm:$false | Out-Null
-    } elseif ($ReadmeTable -eq 'EvtxNative') {
-        Update-BenchmarkDocument `
-            -Path $readmePath `
-            -BlockId 'event-log-evtx-native-benchmark' `
             -ComparisonPath $benchmarkResult.Artifacts['comparison.json'] `
             -Renderer ComparisonTable `
             -Confirm:$false | Out-Null

--- a/Benchmarks/EventLogParsing/README.md
+++ b/Benchmarks/EventLogParsing/README.md
@@ -104,6 +104,82 @@ PowerForge records:
 Every generated public table requires at least three rotated iterations. A one-off diagnostic run remains useful while
 developing, but the wrapper refuses to publish it into the README.
 
+## Detailed published evidence
+
+The main README keeps the current measurements that help users choose a query, startup, or reporting path. This
+section retains lower-level evidence used to change the engine and exporters: common public work, byte-identical
+exports, different-schema native exports, and standalone characterization of the external benchmark tool.
+
+These tables use a 231,804,928-byte Security EVTX containing 190,645 readable events
+(`FF2F428E0D7DD59EEEA3A5D87477AFFECD87C6541DF417261F21E4B144E7D6AD`) on the same 32-logical-processor Windows host,
+with .NET SDK 10.0.302 and PowerShell 7.6.4. EvtxECmd was pinned to
+`2026.5.0+bfc7f47ccbf65ffc9a3777cde5498db2fdd94664`
+(`DE169B2AC7F6B1E54A684E0CDDDA30223651937B75941B21EA53A98F5A2502EE`), and the 386-file maps manifest was hashed.
+Comparison cells show elapsed time and a ratio to the row's `1.00x` reference; lower is faster. `Skipped` means the
+lane was not part of that case. Output-size ratios describe different payload sizes, not quality or speed.
+
+### Common public work
+
+These rows hold the input window and materialization category equal, but each public API returns its natural object
+schema.
+
+<!-- event-log-common-benchmark:start -->
+| Scenario | Host | Operation | PSEventViewer | DotNet | EventViewerX | GetWinEvent | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Large-Common-Sample-Full | Core-7.6.4 | Scan | 1.00x (12.22s) | 4.00x (48.93s) | 1.12x (13.70s) | 4.70x (57.45s) | Fastest: PSEventViewer |
+| Large-Common-Sample-Message | Core-7.6.4 | Scan | 1.00x (10.45s) | 4.67x (48.78s) | 0.81x (8.51s) | 4.89x (51.12s) | Fastest: EventViewerX |
+| Large-Common-Sample-StructuredData | Core-7.6.4 | Scan | 1.00x (3.25s) | 1.21x (3.94s) | 0.94x (3.04s) | 8.20x (26.63s) | Fastest: EventViewerX |
+| Large-Common-Scan-Metadata | Core-7.6.4 | Scan | 1.00x (2.54s) | 0.83x (2.10s) | 0.72x (1.82s) | 17.27x (43.90s) | Fastest: EventViewerX |
+<!-- event-log-common-benchmark:end -->
+
+### Byte-identical exports
+
+These are direct end-to-end comparisons. Each successful lane produced identical bytes and SHA-256 for its case.
+
+<!-- event-log-exact-output-benchmark:start -->
+| Scenario | Host | Operation | Metric | PSEventViewer | DotNet | EventViewerXExport | GetWinEvent | Result |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Large-Exact-Export-MetadataCsv | Core-7.6.4 | Scan | MedianMs | 1.00x (3.83s) | 0.69x (2.64s) | Skipped | 12.66x (48.46s) | Fastest: DotNet |
+| Large-Exact-Export-MetadataCsv | Core-7.6.4 | Scan | OutputBytes | 1.00x (19055567) | 1.00x (19055567) | Skipped | 1.00x (19055567) | Reference: PSEventViewer |
+| Large-Exact-Export-RawXml | Core-7.6.4 | Scan | MedianMs | 1.00x (3.68s) | 1.30x (4.80s) | 0.85x (3.12s) | 13.58x (50.01s) | Fastest: EventViewerXExport |
+| Large-Exact-Export-RawXml | Core-7.6.4 | Scan | OutputBytes | 1.00x (293062655) | 1.00x (293062655) | 1.00x (293062655) | 1.00x (293062655) | Reference: PSEventViewer |
+<!-- event-log-exact-output-benchmark:end -->
+
+### Different-schema native exports
+
+EventViewerX and EvtxECmd native formats are not interchangeable. Read duration together with output size and field
+coverage; these rows do not support an unqualified speed claim. EventViewerX full JSON includes provider-formatted
+messages, typed properties, named data, render status, raw XML, and attachments.
+
+<!-- event-log-native-output-benchmark:start -->
+| Scenario | Host | Operation | Metric | EventViewerXExport | EvtxECmd | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| Large-Native-Output-Csv | Core-7.6.4 | Scan | MedianMs | 1.00x (26.46s) | 1.09x (28.73s) | Fastest: EventViewerXExport |
+| Large-Native-Output-Csv | Core-7.6.4 | Scan | OutputBytes | 1.00x (698462495) | 0.46x (318630958) | Reference: EventViewerXExport |
+| Large-Native-Output-FullJson | Core-7.6.4 | Scan | MedianMs | 1.00x (32.02s) | 1.27x (40.58s) | Fastest: EventViewerXExport |
+| Large-Native-Output-FullJson | Core-7.6.4 | Scan | OutputBytes | 1.00x (915259866) | 0.32x (292846026) | Reference: EventViewerXExport |
+| Large-Native-Output-Xml | Core-7.6.4 | Scan | MedianMs | 1.00x (2.85s) | 11.15x (31.78s) | Fastest: EventViewerXExport |
+| Large-Native-Output-Xml | Core-7.6.4 | Scan | OutputBytes | 1.00x (293062655) | 1.12x (329124038) | Reference: EventViewerXExport |
+<!-- event-log-native-output-benchmark:end -->
+
+### EvtxECmd-native workflows
+
+These rows measure only EvtxECmd. They do not imply that another lane failed. A zero-byte parse row means the tool
+parsed and validated the log without writing an export file.
+
+<!-- event-log-evtx-native-benchmark:start -->
+| Scenario | Host | Operation | Metric | EvtxECmd |
+| --- | --- | --- | --- | ---: |
+| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | MedianMs | 26.09s |
+| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | OutputBytes | 318630958 |
+| Large-Evtx-FullJson | Core-7.6.4 | Scan | MedianMs | 36.26s |
+| Large-Evtx-FullJson | Core-7.6.4 | Scan | OutputBytes | 292846026 |
+| Large-Evtx-NativeParse | Core-7.6.4 | Scan | MedianMs | 17.53s |
+| Large-Evtx-NativeParse | Core-7.6.4 | Scan | OutputBytes | 0 |
+| Large-Evtx-Xml | Core-7.6.4 | Scan | MedianMs | 31.96s |
+| Large-Evtx-Xml | Core-7.6.4 | Scan | OutputBytes | 329124038 |
+<!-- event-log-evtx-native-benchmark:end -->
+
 The scale matrix runs 1,000, 10,000, 100,000, and 1,000,000 event windows when the supplied fixture contains enough
 records. The cold-start matrix measures a fresh `evx.exe`, a fresh PowerShell process importing PSEventViewer, and a
 fresh PowerShell process running `Get-WinEvent`. Pass `-PSEventViewerPath` with the manifest from the unpacked module
@@ -132,7 +208,7 @@ Run a smoke comparison:
     -IterationCount 3
 ```
 
-Generate the common-work table in the main README from an external large fixture:
+Generate the common-work table in this benchmark guide from an external large fixture:
 
 ```powershell
 .\Benchmarks\EventLogParsing\Invoke-EventLogParsingBenchmark.ps1 `
@@ -169,9 +245,9 @@ typed query and normalized snapshot:
 
 ```powershell
 .\Benchmarks\EventLogParsing\Invoke-EventLogParsingBenchmark.ps1 `
-    -LargeFixturePath C:\Temp\Security.evtx `
-    -ExpectedLargeCount 1000000 `
-    -ExpensiveSampleCount 1000 `
+    -TypedFixturePath C:\Temp\Security.evtx `
+    -ExpectedTypedCount 1000000 `
+    -ReportSampleCount 1000 `
     -IterationCount 3 `
     -ReadmeTable Reporting
 ```

--- a/Benchmarks/EventLogParsing/README.md
+++ b/Benchmarks/EventLogParsing/README.md
@@ -9,17 +9,20 @@ The committed smoke fixture contains 184 events. Large fixtures remain external 
 
 ## Comparison contract
 
-The suite keeps four kinds of evidence separate:
+The suite keeps three kinds of published evidence separate:
 
 | Class | What is held equal | What the result means |
 | --- | --- | --- |
 | Apples to apples: exact output | Same EVTX, event order, schema, encoding, row/event count, byte count, and SHA-256 | A direct end-to-end comparison. The engines must create the same metadata CSV or raw XML document byte for byte. |
 | Apples to apples: common user job | Same EVTX, direction, maximum event count, read-mode category, streaming consumer, and event order and identity checks | A comparison of the natural public APIs for the same user job. PSEventViewer may return additional parsed fields, and those extra counters are reported. |
 | Apples to oranges: complete native output | Same EVTX, validated event count, and broadly similar output purpose, but EventViewerX and EvtxECmd use different schemas and output volumes | Useful operational evidence, but not an interchangeable-output or unqualified speed claim. |
-| EvtxECmd-native workflow | EvtxECmd's own parse and export modes, measured without pretending another engine performs the same work | A reproducible description of the external tool's native workflows. |
 
 Do not combine rows from different classes into a single “faster than” claim. In particular, comparing a five-column
 metadata CSV with EvtxECmd's forensic CSV compares different work and different output volumes.
+
+EvtxECmd is a competing tool, but its tool-only parse and export cases are diagnostics rather than EventViewerX
+performance evidence. They remain runnable so maintainers can understand the external side of a different-schema
+comparison, but the documentation does not publish a one-engine table as though it were a product comparison.
 
 ## Engines
 
@@ -108,7 +111,7 @@ developing, but the wrapper refuses to publish it into the README.
 
 The main README keeps the current measurements that help users choose a query, startup, or reporting path. This
 section retains lower-level evidence used to change the engine and exporters: common public work, byte-identical
-exports, different-schema native exports, and standalone characterization of the external benchmark tool.
+exports, and different-schema native exports.
 
 These tables use a 231,804,928-byte Security EVTX containing 190,645 readable events
 (`FF2F428E0D7DD59EEEA3A5D87477AFFECD87C6541DF417261F21E4B144E7D6AD`) on the same 32-logical-processor Windows host,
@@ -161,24 +164,6 @@ messages, typed properties, named data, render status, raw XML, and attachments.
 | Large-Native-Output-Xml | Core-7.6.4 | Scan | MedianMs | 1.00x (2.85s) | 11.15x (31.78s) | Fastest: EventViewerXExport |
 | Large-Native-Output-Xml | Core-7.6.4 | Scan | OutputBytes | 1.00x (293062655) | 1.12x (329124038) | Reference: EventViewerXExport |
 <!-- event-log-native-output-benchmark:end -->
-
-### EvtxECmd-native workflows
-
-These rows measure only EvtxECmd. They do not imply that another lane failed. A zero-byte parse row means the tool
-parsed and validated the log without writing an export file.
-
-<!-- event-log-evtx-native-benchmark:start -->
-| Scenario | Host | Operation | Metric | EvtxECmd |
-| --- | --- | --- | --- | ---: |
-| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | MedianMs | 26.09s |
-| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | OutputBytes | 318630958 |
-| Large-Evtx-FullJson | Core-7.6.4 | Scan | MedianMs | 36.26s |
-| Large-Evtx-FullJson | Core-7.6.4 | Scan | OutputBytes | 292846026 |
-| Large-Evtx-NativeParse | Core-7.6.4 | Scan | MedianMs | 17.53s |
-| Large-Evtx-NativeParse | Core-7.6.4 | Scan | OutputBytes | 0 |
-| Large-Evtx-Xml | Core-7.6.4 | Scan | MedianMs | 31.96s |
-| Large-Evtx-Xml | Core-7.6.4 | Scan | OutputBytes | 329124038 |
-<!-- event-log-evtx-native-benchmark:end -->
 
 The scale matrix runs 1,000, 10,000, 100,000, and 1,000,000 event windows when the supplied fixture contains enough
 records. The cold-start matrix measures a fresh `evx.exe`, a fresh PowerShell process importing PSEventViewer, and a
@@ -274,7 +259,7 @@ Generate the different-schema EventViewerX/EvtxECmd export table:
     -ReadmeTable NativeOutput
 ```
 
-Generate the separate EvtxECmd-native workflow table:
+Run the EvtxECmd-native workflows as diagnostic measurements without publishing a comparison table:
 
 ```powershell
 .\Benchmarks\EventLogParsing\Invoke-EventLogParsingBenchmark.ps1 `
@@ -283,7 +268,8 @@ Generate the separate EvtxECmd-native workflow table:
     -EvtxECmdPath C:\Tools\EvtxECmd.exe `
     -EvtxMapsPath C:\Tools\Maps `
     -IterationCount 3 `
-    -ReadmeTable EvtxNative
+    -Case Large-Evtx-NativeParse, Large-Evtx-ForensicCsv, Large-Evtx-FullJson, Large-Evtx-Xml `
+    -Engine EvtxECmd
 ```
 
 `-ReadmeTable` owns its curated case and engine matrix so a partial run cannot silently replace a public table. The

--- a/Benchmarks/EventLogParsing/event-log-parsing.benchmark.ps1
+++ b/Benchmarks/EventLogParsing/event-log-parsing.benchmark.ps1
@@ -23,8 +23,8 @@ $benchmarkWrapper = Join-Path $PSScriptRoot 'Invoke-EventLogParsingBenchmark.ps1
 $benchmarkSpec = Join-Path $PSScriptRoot 'event-log-parsing.benchmark.ps1'
 $pwshPath = [string] (Get-Command pwsh -ErrorAction Stop).Source
 $dotnetPath = [string] (Get-Command dotnet -ErrorAction Stop).Source
-if ($readmeTable -notin 'None', 'Common', 'Scale', 'ColdStart', 'Reporting', 'ExactOutput', 'NativeOutput', 'EvtxNative') {
-    throw "ReadmeTable must be None, Common, Scale, ColdStart, Reporting, ExactOutput, NativeOutput, or EvtxNative. Received '$readmeTable'."
+if ($readmeTable -notin 'None', 'Common', 'Scale', 'ColdStart', 'Reporting', 'ExactOutput', 'NativeOutput') {
+    throw "ReadmeTable must be None, Common, Scale, ColdStart, Reporting, ExactOutput, or NativeOutput. Received '$readmeTable'."
 }
 [long[]] $scaleSampleCounts = @($scaleSampleCountsText.Split(',') |
         ForEach-Object {
@@ -1157,9 +1157,6 @@ New-BenchmarkSuite 'event-log-parsing' -OutputRoot (Join-Path $repositoryRoot 'I
     } elseif ($readmeTable -eq 'NativeOutput') {
         Add-BenchmarkComparison Engine -Baseline EventViewerXExport -Metric MedianMs -TieTolerance 0.03
         Add-BenchmarkComparison Engine -Baseline EventViewerXExport -Metric OutputBytes
-    } elseif ($readmeTable -eq 'EvtxNative') {
-        Add-BenchmarkComparison Engine -Baseline EvtxECmd -Metric MedianMs -TieTolerance 0.03
-        Add-BenchmarkComparison Engine -Baseline EvtxECmd -Metric OutputBytes
     }
     Set-BenchmarkArtifacts Json, Csv, Markdown
 }

--- a/Benchmarks/EventProjection/Invoke-EventProjectionBenchmark.ps1
+++ b/Benchmarks/EventProjection/Invoke-EventProjectionBenchmark.ps1
@@ -54,7 +54,7 @@ if (-not $SkipBuild.IsPresent) {
 }
 
 Add-Type -Path $fixtureAssembly -ErrorAction Stop
-Import-Module PSPublishModule -MinimumVersion 3.0.76 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.134 -Force -ErrorAction Stop
 $invoke = @{
     Path = $specPath
     OutputRoot = [IO.Path]::GetFullPath($OutputRoot)

--- a/Benchmarks/EventProjection/README.md
+++ b/Benchmarks/EventProjection/README.md
@@ -17,8 +17,8 @@ isolated `-OutputRoot` for smoke runs.
 <!-- event-projection-comparison:start -->
 | Scenario | Variables | Host | Operation | CompilePerEvent | ReusablePlan | Result |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| Authentication-1000 | EventCount=1000 | Core-7.6.4 | Project | 1.00x (22ms) | 0.38x (8ms) | CompilePerEvent slower than ReusablePlan |
-| Authentication-10000 | EventCount=10000 | Core-7.6.4 | Project | 1.00x (133ms) | 0.37x (49ms) | CompilePerEvent slower than ReusablePlan |
+| Authentication-1000 | EventCount=1000 | Core-7.6.4 | Project | 1.00x (22ms) | 0.38x (8ms) | Fastest: ReusablePlan |
+| Authentication-10000 | EventCount=10000 | Core-7.6.4 | Project | 1.00x (133ms) | 0.37x (49ms) | Fastest: ReusablePlan |
 <!-- event-projection-comparison:end -->
 
 <!-- event-projection-summary:start -->

--- a/Benchmarks/EventSources/Invoke-EventSourceBenchmark.ps1
+++ b/Benchmarks/EventSources/Invoke-EventSourceBenchmark.ps1
@@ -59,7 +59,7 @@ if (-not $SkipBuild.IsPresent) {
 }
 
 Import-Module $modulePath -Force -ErrorAction Stop
-Import-Module PSPublishModule -MinimumVersion 3.0.76 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.134 -Force -ErrorAction Stop
 $boundaryParameters = @{
     LogName = $LogName
     MaxEvents = 1

--- a/Benchmarks/EventStore/Invoke-EventStoreBenchmark.ps1
+++ b/Benchmarks/EventStore/Invoke-EventStoreBenchmark.ps1
@@ -65,7 +65,7 @@ if (-not $SkipBuild.IsPresent) {
 
 Import-Module $modulePath -Force -ErrorAction Stop
 Add-Type -Path $fixtureAssemblyPath -ErrorAction Stop
-Import-Module PSPublishModule -MinimumVersion 3.0.76 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.134 -Force -ErrorAction Stop
 $results = foreach ($currentRowCount in $resolvedRowCounts) {
     $invoke = @{
         Path = $specPath

--- a/Benchmarks/EventWatcher/Invoke-EventWatcherBurstBenchmark.ps1
+++ b/Benchmarks/EventWatcher/Invoke-EventWatcherBurstBenchmark.ps1
@@ -52,7 +52,7 @@ if (-not $Plan.IsPresent) {
     }
 }
 
-Import-Module PSPublishModule -MinimumVersion 3.0.76 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.134 -Force -ErrorAction Stop
 $invoke = @{
     Path = $specPath
     OutputRoot = [IO.Path]::GetFullPath($OutputRoot)

--- a/README.md
+++ b/README.md
@@ -1024,147 +1024,99 @@ Version 4 is a deliberate API cleanup:
 These are breaking changes intended to remove duplicate behavior and make cost,
 ownership, and failure boundaries predictable.
 
-## Performance evidence
+## Performance
 
-The [event query PowerForge suite](Benchmarks/EventLogParsing/README.md)
-separates byte-identical comparisons from common public jobs and
-different-schema native exports. The independent
-[local history suite](Benchmarks/EventStore/README.md) measures transactional
-ingestion, indexed and managed typed queries, UTC calendar summaries, and typed
-CSV from identical normalized rows. Every published result requires at least
-three rotated iterations plus contract validation.
+These measurements answer four practical questions: how query cost scales,
+what a remote query costs in one lab, how quickly a new process starts, and how
+much each report format adds. They are not a universal ranking. Event log
+contents, provider message rendering, filters, storage, network latency, and
+machine state can change the result.
 
-The current v4 scale, typed-report, and cold-start runs use a
-225,513,472-byte Security EVTX containing 201,672 readable events
-(`4F61E29AEAC9D3D7DDE4EE74CF8EE7AB9C5A4BF21FBE610E326A91566CC2A383`).
-The remote matrix pins a live AD0 record boundary so all three engines read
-the same records. Those runs used the same 32-logical-processor Windows host
-with .NET SDK 10.0.400 and PowerShell 7.6.4.
+The [PowerForge event-query suite](Benchmarks/EventLogParsing/README.md) runs at
+least three rotated iterations and validates event count, identity, and order
+before it updates a published table. Comparison cells show elapsed time and a
+ratio to the row's `1.00x` reference; lower is faster. `Skipped` means that a
+lane was deliberately not measured, not that it failed.
 
-The earlier common-work, byte-identical export, and EvtxECmd-native tables use
-a 231,804,928-byte Security EVTX containing 190,645 readable events
-(`FF2F428E0D7DD59EEEA3A5D87477AFFECD87C6541DF417261F21E4B144E7D6AD`)
-and .NET SDK 10.0.302. EvtxECmd was pinned to
-`2026.5.0+bfc7f47ccbf65ffc9a3777cde5498db2fdd94664`
-(`DE169B2AC7F6B1E54A684E0CDDDA30223651937B75941B21EA53A98F5A2502EE`);
-its 386-file maps manifest was also hashed. Generated payloads are deleted
-after their size and SHA-256 are validated, while the small summaries and
-provenance remain.
+The current scale and report measurements use a 225,513,472-byte Security EVTX
+containing 201,672 readable events on a 32-logical-processor Windows host with
+.NET SDK 10.0.400 and PowerShell 7.6.4. The cold-start case uses the committed
+184-event smoke fixture and reads one event so it measures process and module
+startup rather than large-log throughput. Results describe those fixtures and
+that host.
 
-<!-- event-log-common-benchmark:start -->
-| Scenario | Host | Operation | PSEventViewer | DotNet | EventViewerX | GetWinEvent | Result |
-| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| Large-Common-Sample-Full | Core-7.6.4 | Scan | 1.00x (12.22s) | 4.00x (48.93s) | 1.12x (13.70s) | 4.70x (57.45s) | PSEventViewer fastest |
-| Large-Common-Sample-Message | Core-7.6.4 | Scan | 1.00x (10.45s) | 4.67x (48.78s) | 0.81x (8.51s) | 4.89x (51.12s) | PSEventViewer slower than EventViewerX |
-| Large-Common-Sample-StructuredData | Core-7.6.4 | Scan | 1.00x (3.25s) | 1.21x (3.94s) | 0.94x (3.04s) | 8.20x (26.63s) | PSEventViewer slower than EventViewerX |
-| Large-Common-Scan-Metadata | Core-7.6.4 | Scan | 1.00x (2.54s) | 0.83x (2.10s) | 0.72x (1.82s) | 17.27x (43.90s) | PSEventViewer slower than EventViewerX |
-<!-- event-log-common-benchmark:end -->
+### Query throughput
 
-Common-public-job rows keep the input window and materialization category
-equal, but the public APIs can return different object schemas. Exact-output
-rows below require identical bytes and SHA-256.
-
-### Scale and cold-start behavior
-
-The scale matrix uses one real Security EVTX and fixed 1,000, 10,000, and
-100,000-event windows. Every cell validates count, record identity, and order;
-the table compares public jobs with equivalent materialization categories, not
-byte-identical output schemas.
+The scale matrix reads fixed 1,000, 10,000, and 100,000-event windows. It
+compares equivalent public jobs, although the returned object schemas are not
+byte-identical. EventViewerX was fastest in every measured row. The largest
+gain appears in `Metadata`; formatted messages and full materialization narrow
+the gap because Windows provider work becomes a larger part of the total cost.
 
 <!-- event-log-scale-benchmark:start -->
 | Scenario | Host | Operation | PSEventViewer | DotNet | EventViewerX | GetWinEvent | Result |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| Large-Scale-1000-Full | Core-7.6.4 | Scan | 1.00x (669ms) | 0.88x (590ms) | 0.39x (261ms) | 1.70x (1.14s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-1000-Metadata | Core-7.6.4 | Scan | 1.00x (498ms) | 0.23x (116ms) | 0.22x (109ms) | 1.59x (794ms) | PSEventViewer slower than EventViewerX |
-| Large-Scale-1000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (680ms) | 0.90x (613ms) | 0.37x (252ms) | 1.68x (1.14s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-10000-Full | Core-7.6.4 | Scan | 1.00x (2.49s) | 1.88x (4.69s) | 0.63x (1.56s) | 2.26x (5.63s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-10000-Metadata | Core-7.6.4 | Scan | 1.00x (616ms) | 0.35x (218ms) | 0.30x (183ms) | 4.50x (2.77s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-10000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (2.46s) | 1.95x (4.79s) | 0.60x (1.49s) | 2.33x (5.72s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-100000-Full | Core-7.6.4 | Scan | 1.00x (14.63s) | 2.97x (43.40s) | 0.75x (10.92s) | 3.32x (48.59s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-100000-Metadata | Core-7.6.4 | Scan | 1.00x (1.80s) | 0.61x (1.09s) | 0.48x (859ms) | 10.85x (19.49s) | PSEventViewer slower than EventViewerX |
-| Large-Scale-100000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (14.44s) | 3.00x (43.27s) | 0.73x (10.56s) | 3.37x (48.65s) | PSEventViewer slower than EventViewerX |
+| Large-Scale-1000-Full | Core-7.6.4 | Scan | 1.00x (669ms) | 0.88x (590ms) | 0.39x (261ms) | 1.70x (1.14s) | Fastest: EventViewerX |
+| Large-Scale-1000-Metadata | Core-7.6.4 | Scan | 1.00x (498ms) | 0.23x (116ms) | 0.22x (109ms) | 1.59x (794ms) | Fastest: EventViewerX |
+| Large-Scale-1000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (680ms) | 0.90x (613ms) | 0.37x (252ms) | 1.68x (1.14s) | Fastest: EventViewerX |
+| Large-Scale-10000-Full | Core-7.6.4 | Scan | 1.00x (2.49s) | 1.88x (4.69s) | 0.63x (1.56s) | 2.26x (5.63s) | Fastest: EventViewerX |
+| Large-Scale-10000-Metadata | Core-7.6.4 | Scan | 1.00x (616ms) | 0.35x (218ms) | 0.30x (183ms) | 4.50x (2.77s) | Fastest: EventViewerX |
+| Large-Scale-10000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (2.46s) | 1.95x (4.79s) | 0.60x (1.49s) | 2.33x (5.72s) | Fastest: EventViewerX |
+| Large-Scale-100000-Full | Core-7.6.4 | Scan | 1.00x (14.63s) | 2.97x (43.40s) | 0.75x (10.92s) | 3.32x (48.59s) | Fastest: EventViewerX |
+| Large-Scale-100000-Metadata | Core-7.6.4 | Scan | 1.00x (1.80s) | 0.61x (1.09s) | 0.48x (859ms) | 10.85x (19.49s) | Fastest: EventViewerX |
+| Large-Scale-100000-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (14.44s) | 3.00x (43.27s) | 0.73x (10.56s) | 3.37x (48.65s) | Fastest: EventViewerX |
 <!-- event-log-scale-benchmark:end -->
 
-Remote evidence includes connection/session and network cost. The wrapper pins
-one latest record boundary before the rotated run, and every engine must return
-the same ordered record identities. These AD0 results describe this lab and
-time; the offline scale table remains the reproducible throughput evidence.
+### Remote queries
+
+Remote measurements include connection, session, and network cost. The suite
+pins one record boundary and requires every engine to return the same ordered
+records. These AD0 results describe one lab at one point in time; use the local
+scale table for reproducible throughput comparisons.
 
 <!-- event-log-remote-benchmark:start -->
 | Scenario | Variables | Host | Operation | PSEventViewer | EventViewerX | GetWinEvent | Result |
 | --- | --- | --- | --- | ---: | ---: | ---: | --- |
-| Remote-AD0-Security-Latest-100-Metadata | EventCount=100, LogName=Security, MachineName=AD0 | Core-7.6.4 | Query | 1.00x (69ms) | 0.70x (48ms) | 7.89x (546ms) | PSEventViewer slower than EventViewerX |
-| Remote-AD0-Security-Latest-1000-Metadata | EventCount=1000, LogName=Security, MachineName=AD0 | Core-7.6.4 | Query | 1.00x (377ms) | 0.93x (350ms) | 19.42x (7.32s) | PSEventViewer slower than EventViewerX |
+| Remote-AD0-Security-Latest-100-Metadata | EventCount=100, LogName=Security, MachineName=AD0 | Core-7.6.4 | Query | 1.00x (69ms) | 0.70x (48ms) | 7.89x (546ms) | Fastest: EventViewerX |
+| Remote-AD0-Security-Latest-1000-Metadata | EventCount=1000, LogName=Security, MachineName=AD0 | Core-7.6.4 | Query | 1.00x (377ms) | 0.93x (350ms) | 19.42x (7.32s) | Fastest: EventViewerX |
 <!-- event-log-remote-benchmark:end -->
+
+### Process startup
 
 Cold-start measurements launch a fresh process for every sample. They answer
 the Task Scheduler and event-triggered automation question separately from
-steady-state scan throughput.
+steady-state scan throughput. In this run, both CLI forms started in about
+115ms; the PowerShell command paths took about 590ms.
 
 <!-- event-log-cold-start-benchmark:start -->
 | Scenario | Host | Operation | EventViewerXCli | EventViewerXCliPortable | GetWinEvent | PSEventViewer | Result |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| Smoke-Command-Cold-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (115ms) | 1.01x (116ms) | 5.15x (590ms) | 5.14x (590ms) | EventViewerXCli tied with EventViewerXCliPortable |
+| Smoke-Command-Cold-StructuredDataAndMessage | Core-7.6.4 | Scan | 1.00x (115ms) | 1.01x (116ms) | 5.15x (590ms) | 5.14x (590ms) | Fastest: EventViewerXCli, EventViewerXCliPortable (tie) |
 <!-- event-log-cold-start-benchmark:end -->
+
+### Report generation
 
 Reporting measurements include the typed query and the requested renderer.
 `All` creates the interactive HTML report, Excel workbook, and compact email
-body in one operation; individual formats avoid work the caller does not need.
+body in one operation. On the measured 1,000-event window, HTML and email each
+completed in under 0.7s, while Excel took about 6.1s. Request only the formats
+you need.
 
 <!-- event-log-reporting-benchmark:start -->
-| Scenario | Host | Operation | EventViewerXReport | Result |
-| --- | --- | --- | ---: | --- |
-| Typed-Report-All | Core-7.6.4 | Scan | 1.00x (6.58s) | EventViewerXReport only successful |
-| Typed-Report-Email | Core-7.6.4 | Scan | 1.00x (510ms) | EventViewerXReport only successful |
-| Typed-Report-Excel | Core-7.6.4 | Scan | 1.00x (6.08s) | EventViewerXReport only successful |
-| Typed-Report-Html | Core-7.6.4 | Scan | 1.00x (689ms) | EventViewerXReport only successful |
+| Scenario | Host | Operation | EventViewerXReport |
+| --- | --- | --- | ---: |
+| Typed-Report-All | Core-7.6.4 | Scan | 6.58s |
+| Typed-Report-Email | Core-7.6.4 | Scan | 510ms |
+| Typed-Report-Excel | Core-7.6.4 | Scan | 6.08s |
+| Typed-Report-Html | Core-7.6.4 | Scan | 689ms |
 <!-- event-log-reporting-benchmark:end -->
 
-<!-- event-log-exact-output-benchmark:start -->
-| Scenario | Host | Operation | Metric | PSEventViewer | DotNet | EventViewerXExport | GetWinEvent | Result |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| Large-Exact-Export-MetadataCsv | Core-7.6.4 | Scan | MedianMs | 1.00x (3.83s) | 0.69x (2.64s) | Skipped | 12.66x (48.46s) | PSEventViewer slower than DotNet |
-| Large-Exact-Export-MetadataCsv | Core-7.6.4 | Scan | OutputBytes | 1.00x (19055567) | 1.00x (19055567) | Skipped | 1.00x (19055567) | PSEventViewer baseline |
-| Large-Exact-Export-RawXml | Core-7.6.4 | Scan | MedianMs | 1.00x (3.68s) | 1.30x (4.80s) | 0.85x (3.12s) | 13.58x (50.01s) | PSEventViewer slower than EventViewerXExport |
-| Large-Exact-Export-RawXml | Core-7.6.4 | Scan | OutputBytes | 1.00x (293062655) | 1.00x (293062655) | 1.00x (293062655) | 1.00x (293062655) | PSEventViewer baseline |
-<!-- event-log-exact-output-benchmark:end -->
-
-EventViewerX and EvtxECmd native formats are not interchangeable. Read these
-times together with output bytes and fields; do not turn them into an
-unqualified speed claim.
-
-<!-- event-log-native-output-benchmark:start -->
-| Scenario | Host | Operation | Metric | EventViewerXExport | EvtxECmd | Result |
-| --- | --- | --- | --- | ---: | ---: | --- |
-| Large-Native-Output-Csv | Core-7.6.4 | Scan | MedianMs | 1.00x (26.46s) | 1.09x (28.73s) | EventViewerXExport fastest |
-| Large-Native-Output-Csv | Core-7.6.4 | Scan | OutputBytes | 1.00x (698462495) | 0.46x (318630958) | EventViewerXExport baseline |
-| Large-Native-Output-FullJson | Core-7.6.4 | Scan | MedianMs | 1.00x (32.02s) | 1.27x (40.58s) | EventViewerXExport fastest |
-| Large-Native-Output-FullJson | Core-7.6.4 | Scan | OutputBytes | 1.00x (915259866) | 0.32x (292846026) | EventViewerXExport baseline |
-| Large-Native-Output-Xml | Core-7.6.4 | Scan | MedianMs | 1.00x (2.85s) | 11.15x (31.78s) | EventViewerXExport fastest |
-| Large-Native-Output-Xml | Core-7.6.4 | Scan | OutputBytes | 1.00x (293062655) | 1.12x (329124038) | EventViewerXExport baseline |
-<!-- event-log-native-output-benchmark:end -->
-
-EventViewerX full JSON includes provider-formatted messages, typed properties,
-named data, render status, raw XML, and attachments. The generated
-`OutputBytes` rows make that extra work visible instead of hiding it inside an
-unqualified timing claim. EvtxECmd is only a pinned external benchmark target
-and is not a source, package, or runtime dependency.
-
-<!-- event-log-evtx-native-benchmark:start -->
-| Scenario | Host | Operation | Metric | EvtxECmd | Result |
-| --- | --- | --- | --- | ---: | --- |
-| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | MedianMs | 1.00x (26.09s) | EvtxECmd only successful |
-| Large-Evtx-ForensicCsv | Core-7.6.4 | Scan | OutputBytes | 1.00x (318630958) | EvtxECmd baseline |
-| Large-Evtx-FullJson | Core-7.6.4 | Scan | MedianMs | 1.00x (36.26s) | EvtxECmd only successful |
-| Large-Evtx-FullJson | Core-7.6.4 | Scan | OutputBytes | 1.00x (292846026) | EvtxECmd baseline |
-| Large-Evtx-NativeParse | Core-7.6.4 | Scan | MedianMs | 1.00x (17.53s) | EvtxECmd only successful |
-| Large-Evtx-NativeParse | Core-7.6.4 | Scan | OutputBytes | n/a (0) | EvtxECmd baseline |
-| Large-Evtx-Xml | Core-7.6.4 | Scan | MedianMs | 1.00x (31.96s) | EvtxECmd only successful |
-| Large-Evtx-Xml | Core-7.6.4 | Scan | OutputBytes | 1.00x (329124038) | EvtxECmd baseline |
-<!-- event-log-evtx-native-benchmark:end -->
-
-The committed smoke fixture is small and non-sensitive. Large EVTX fixtures
-and generated multi-gigabyte outputs remain external and temporary.
+The benchmark guide keeps the byte-identical export results, different-schema
+native export measurements, external-tool characterization, commands, and full
+provenance. Those details are useful when changing the engine or exporter, but
+they are not presented here as general EventViewerX performance claims. The
+independent [local history suite](Benchmarks/EventStore/README.md) covers
+transactional ingestion, indexed queries, summaries, and typed CSV generation.
 
 ## Runtime dependencies
 

--- a/README.md
+++ b/README.md
@@ -1112,9 +1112,9 @@ you need.
 <!-- event-log-reporting-benchmark:end -->
 
 The benchmark guide keeps the byte-identical export results, different-schema
-native export measurements, external-tool characterization, commands, and full
-provenance. Those details are useful when changing the engine or exporter, but
-they are not presented here as general EventViewerX performance claims. The
+native export comparisons, commands, and full provenance. Those details are
+useful when changing the engine or exporter, but they are not presented here
+as general EventViewerX performance claims. The
 independent [local history suite](Benchmarks/EventStore/README.md) covers
 transactional ingestion, indexed queries, summaries, and typed CSV generation.
 


### PR DESCRIPTION
## Summary

- replace the long mixed performance section with four user decisions: query throughput, remote-query context, process startup, and report-format cost
- move byte-identical and different-schema export evidence into the benchmark guide with their comparison contracts and provenance
- remove the standalone EvtxECmd table and its public-generation mode because a one-engine measurement cannot support an EventViewerX performance claim
- make every benchmark wrapper consume the shared readable-table behavior from PSPublishModule 3.0.134

## Reader impact

Single-engine EventViewerX rows are plain measurements, so they no longer imply that another engine failed. Real comparison results name the fastest measured lane directly, and the README explains ratios, skipped lanes, fixture boundaries, and the difference between startup and throughput.

EvtxECmd remains a competing benchmark target in the different-schema export matrix. Its tool-only workflows remain runnable as maintainer diagnostics but are no longer published as product evidence.

The reporting example now uses the parameters the wrapper actually requires: `TypedFixturePath`, `ExpectedTypedCount`, and `ReportSampleCount`.

## Ownership and release state

PowerForge owns benchmark rendering. [PSPublishModule PR #871](https://github.com/EvotecIT/PSPublishModule/pull/871) is merged, and [PSPublishModule 3.0.134](https://www.powershellgallery.com/packages/PSPublishModule/3.0.134) is published on PSGallery. EventViewerX consumes that released behavior and does not duplicate the renderer.

## Validation

- PowerShell AST parsing passed for all changed benchmark scripts
- Markdown table column shape and generated block ownership passed
- the standalone EvtxECmd publication path is absent while its diagnostic benchmark cases remain available
- `git diff --check` passed
- PowerForge benchmark-service tests passed: 457/457
- PSPublishModule 3.0.134 downloaded from PSGallery and imported successfully

This does not publish EventViewerX 4.0.
