### PR TITLE
Separate package/module and CLI release lanes

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -38,6 +38,12 @@ jobs:
         run: .\Build\Test-ReleaseGuards.ps1
         shell: pwsh
 
+      - name: Test release selection
+        run: |
+          .\Build\Test-ReleaseConfiguration.ps1
+          .\Build\Test-ReleasePlans.ps1
+        shell: pwsh
+
       - name: Refresh module manifest
         run: |
           .\Build\Build-Module.ps1 -ConfigurationGateMode Manifest

--- a/Build/Build-All.ps1
+++ b/Build/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
     [Alias('ConfigurationGateMode')]
-    [ValidateSet('Manifest', 'Build', 'Publish')]
+    [ValidateSet('Manifest', 'Plan', 'Build', 'Publish')]
     [string] $RunMode = 'Build',
 
     [bool] $SignModule = $true,
@@ -13,6 +13,8 @@ param(
 
     [switch] $SkipCli,
 
+    [switch] $SkipInstall,
+
     [ValidatePattern('^[0-9a-fA-F]{40}$')]
     [string] $ExpectedCommit,
 
@@ -21,15 +23,21 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-if ($RunMode -eq 'Publish' -or ($RunMode -eq 'Build' -and -not $SkipCli)) {
+if ($RunMode -ne 'Manifest') {
     $releaseSplat = @{
         RunMode        = $RunMode
         Version        = $Version
         SignModule     = $SignModule
+        SkipCli        = $SkipCli
+        SkipInstall    = $SkipInstall
     }
     if ($RunMode -eq 'Publish') {
-        $releaseSplat.ExpectedCommit = $ExpectedCommit
-        $releaseSplat.Confirmation = $PublishConfirmation
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedCommit)) {
+            $releaseSplat.ExpectedCommit = $ExpectedCommit
+        }
+        if (-not [string]::IsNullOrWhiteSpace($PublishConfirmation)) {
+            $releaseSplat.Confirmation = $PublishConfirmation
+        }
     }
     if ($PSBoundParameters.ContainsKey('ModuleFramework')) {
         $releaseSplat.ModuleFramework = $ModuleFramework
@@ -40,6 +48,7 @@ if ($RunMode -eq 'Publish' -or ($RunMode -eq 'Build' -and -not $SkipCli)) {
         RunMode      = $RunMode
         SignModule   = $SignModule
         ModuleVersion = $Version
+        SkipInstall  = $SkipInstall
     }
     if ($PSBoundParameters.ContainsKey('ModuleFramework')) {
         $moduleBuildSplat.Framework = $ModuleFramework

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -31,13 +31,50 @@ param(
 
     [switch] $PowerForgeReleaseStage,
 
-    [switch] $SkipInstall
+    [switch] $SkipInstall,
+
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $ExpectedCommit,
+
+    [string] $PublishConfirmation
 )
 
 $ErrorActionPreference = 'Stop'
 
 if ($RunMode -eq 'Publish') {
-    throw 'Direct module publication is disabled. Use Build-Release.ps1 -RunMode Publish so commit, checkout, confirmation, and staged-artifact guards are enforced.'
+    [array] $unsupportedPublishParameters = @(
+        'PreReleaseTag'
+        'Configuration'
+        'NoDotnetBuild'
+        'StagingPath'
+        'ReuseStaging'
+        'IncludeProjectPackages'
+        'IncludeModulePublishing'
+        'PowerForgeUnifiedGitHubRelease'
+        'PowerForgeReleaseStage'
+    ) | Where-Object { $PSBoundParameters.ContainsKey($_) }
+    if ($unsupportedPublishParameters.Count -ne 0) {
+        throw "The guarded package/module publish lane does not support: $($unsupportedPublishParameters -join ', ')."
+    }
+
+    $releaseSplat = @{
+        RunMode      = 'Publish'
+        Version      = $ModuleVersion
+        SignModule   = $SignModule
+        SkipCli      = $true
+        SkipInstall  = $SkipInstall
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedCommit)) {
+        $releaseSplat.ExpectedCommit = $ExpectedCommit
+    }
+    if (-not [string]::IsNullOrWhiteSpace($PublishConfirmation)) {
+        $releaseSplat.Confirmation = $PublishConfirmation
+    }
+    if ($PSBoundParameters.ContainsKey('Framework')) {
+        $releaseSplat.ModuleFramework = $Framework
+    }
+    & (Join-Path $PSScriptRoot 'Build-Release.ps1') @releaseSplat
+    return
 }
 
 Import-Module PSPublishModule -Force

--- a/Build/Build-Release.ps1
+++ b/Build/Build-Release.ps1
@@ -11,6 +11,10 @@ param(
     [ValidateSet('auto', 'net472', 'net8.0', 'net10.0')]
     [string] $ModuleFramework,
 
+    [switch] $SkipCli,
+
+    [switch] $SkipInstall,
+
     [ValidatePattern('^[0-9a-fA-F]{40}$')]
     [string] $ExpectedCommit,
 
@@ -21,7 +25,8 @@ $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [System.IO.Path]::GetFullPath(
     (Join-Path $PSScriptRoot '..'))
-$configPath = Join-Path $PSScriptRoot 'release.json'
+$configName = if ($SkipCli) { 'release.module.json' } else { 'release.json' }
+$configPath = Join-Path $PSScriptRoot $configName
 
 if ($RunMode -eq 'Publish') {
     if ([string]::IsNullOrWhiteSpace($ExpectedCommit)) {
@@ -54,6 +59,9 @@ $invokeSplat = @{
 }
 if ($PSBoundParameters.ContainsKey('ModuleFramework')) {
     $invokeSplat.ModuleFramework = $ModuleFramework
+}
+if ($SkipInstall) {
+    $invokeSplat.ModuleSkipInstall = $true
 }
 switch ($RunMode) {
     'Plan' {

--- a/Build/Test-ModuleReleaseReady.ps1
+++ b/Build/Test-ModuleReleaseReady.ps1
@@ -1,0 +1,6 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'Test-ReleaseReady.ps1') -SkipCliArtifacts

--- a/Build/Test-ReleaseArchitecture.ps1
+++ b/Build/Test-ReleaseArchitecture.ps1
@@ -5,7 +5,9 @@ param(
 
     [string] $ModuleRoot,
 
-    [string] $CliManifestPath
+    [string] $CliManifestPath,
+
+    [switch] $SkipCliArtifacts
 )
 
 $ErrorActionPreference = 'Stop'
@@ -18,22 +20,29 @@ if ([string]::IsNullOrWhiteSpace($ModuleRoot)) {
     $ModuleRoot = Join-Path $RepositoryRoot 'Artefacts\Unpacked\Modules\PSEventViewer'
 }
 $ModuleRoot = [System.IO.Path]::GetFullPath($ModuleRoot)
-if ([string]::IsNullOrWhiteSpace($CliManifestPath)) {
+if (-not $SkipCliArtifacts -and [string]::IsNullOrWhiteSpace($CliManifestPath)) {
     $CliManifestPath = Join-Path $RepositoryRoot `
         'Artefacts\Cli\Artifacts\DotNetPublish\manifest.json'
 }
-$CliManifestPath = [System.IO.Path]::GetFullPath($CliManifestPath)
+if (-not [string]::IsNullOrWhiteSpace($CliManifestPath)) {
+    $CliManifestPath = [System.IO.Path]::GetFullPath($CliManifestPath)
+}
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 $expectedPackages = @(
     'EventViewerX'
-    'EventViewerX.Cli'
     'EventViewerX.Detection'
     'EventViewerX.Evtx'
     'EventViewerX.Reporting'
     'EventViewerX.Storage'
 )
+[array] $deferredCliPackages = Get-ChildItem -LiteralPath $PackageRoot `
+    -Filter 'EventViewerX.Cli.*.nupkg' -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -notlike '*.symbols.nupkg' }
+if ($deferredCliPackages.Count -ne 0) {
+    throw 'EventViewerX.Cli must not be present in the library/module release.'
+}
 $packageMetadata = @{}
 foreach ($packageId in $expectedPackages) {
     $packagePattern = '^' + [regex]::Escape($packageId) + '\.\d'
@@ -98,9 +107,6 @@ function Assert-PackageBoundary {
 
 Assert-PackageBoundary -PackageId 'EventViewerX' -Required @() `
     -Forbidden @('EventViewerX.Cli', 'EventViewerX.Detection', 'EventViewerX.Evtx', 'EventViewerX.Reporting', 'EventViewerX.Storage')
-Assert-PackageBoundary -PackageId 'EventViewerX.Cli' `
-    -Required @() `
-    -Forbidden @('EventViewerX', 'EventViewerX.Detection', 'EventViewerX.Evtx', 'EventViewerX.Reporting', 'EventViewerX.Storage')
 Assert-PackageBoundary -PackageId 'EventViewerX.Detection' -Required @('EventViewerX') `
     -Forbidden @('EventViewerX.Cli', 'EventViewerX.Evtx', 'EventViewerX.Reporting', 'EventViewerX.Storage')
 Assert-PackageBoundary -PackageId 'EventViewerX.Evtx' -Required @('EventViewerX') `
@@ -109,22 +115,6 @@ Assert-PackageBoundary -PackageId 'EventViewerX.Reporting' -Required @('EventVie
     -Forbidden @('EventViewerX.Cli', 'EventViewerX.Detection', 'EventViewerX.Evtx', 'EventViewerX.Storage')
 Assert-PackageBoundary -PackageId 'EventViewerX.Storage' -Required @('EventViewerX') `
     -Forbidden @('EventViewerX.Cli', 'EventViewerX.Detection', 'EventViewerX.Evtx', 'EventViewerX.Reporting')
-if ('DotnetTool' -notin $packageMetadata['EventViewerX.Cli'].PackageTypes) {
-    throw 'EventViewerX.Cli must be packed as a .NET tool.'
-}
-$expectedCliAssemblies = @(
-    'EventViewerX.dll'
-    'EventViewerX.Detection.dll'
-    'EventViewerX.Evtx.dll'
-    'EventViewerX.Reporting.dll'
-    'EventViewerX.Storage.dll'
-)
-foreach ($assemblyName in $expectedCliAssemblies) {
-    if ("tools/net10.0/any/$assemblyName" -notin $packageMetadata['EventViewerX.Cli'].Files) {
-        throw "EventViewerX.Cli does not contain the canonical $assemblyName assembly."
-    }
-}
-
 $manifest = Import-PowerShellDataFile -LiteralPath (Join-Path $moduleRoot 'PSEventViewer.psd1')
 if ([version] $manifest.ModuleVersion -ne [version] $version) {
     throw "PSEventViewer $($manifest.ModuleVersion) does not match package version $version."
@@ -143,27 +133,30 @@ foreach ($assembly in $moduleAssemblies) {
     }
 }
 
-$cliManifest = Get-Content -LiteralPath $CliManifestPath -Raw | ConvertFrom-Json
-$isUnifiedReleaseManifest = $null -ne $cliManifest.PSObject.Properties['assetEntries']
-if ($isUnifiedReleaseManifest) {
-    [array] $cliEntries = $cliManifest.assetEntries | Where-Object { $_.category -eq 'Tool' }
-} else {
-    [array] $cliEntries = $cliManifest | Where-Object {
-        $_.category -eq 'Publish' -and
-        $_.target -eq 'EventViewerX.Cli' -and
-        -not [string]::IsNullOrWhiteSpace([string] $_.zipPath)
+$cliEntries = @()
+if (-not $SkipCliArtifacts) {
+    $cliManifest = Get-Content -LiteralPath $CliManifestPath -Raw | ConvertFrom-Json
+    $isUnifiedReleaseManifest = $null -ne $cliManifest.PSObject.Properties['assetEntries']
+    if ($isUnifiedReleaseManifest) {
+        [array] $cliEntries = $cliManifest.assetEntries | Where-Object { $_.category -eq 'Tool' }
+    } else {
+        [array] $cliEntries = $cliManifest | Where-Object {
+            $_.category -eq 'Publish' -and
+            $_.target -eq 'EventViewerX.Cli' -and
+            -not [string]::IsNullOrWhiteSpace([string] $_.zipPath)
+        }
     }
-}
-if ($cliEntries.Count -ne 12) {
-    throw "Expected 12 CLI runtime/style assets, found $($cliEntries.Count)."
-}
-if ($isUnifiedReleaseManifest -and
-    @($cliEntries | Where-Object { $_.Version -ne $version }).Count -ne 0) {
-    throw "One or more CLI assets do not match release version $version."
-}
-if (-not $isUnifiedReleaseManifest -and
-    @($cliEntries | Where-Object { $_.sourceDirty -ne $false }).Count -ne 0) {
-    throw 'One or more CLI assets do not have clean source provenance.'
+    if ($cliEntries.Count -ne 12) {
+        throw "Expected 12 CLI runtime/style assets, found $($cliEntries.Count)."
+    }
+    if ($isUnifiedReleaseManifest -and
+        @($cliEntries | Where-Object { $_.Version -ne $version }).Count -ne 0) {
+        throw "One or more CLI assets do not match release version $version."
+    }
+    if (-not $isUnifiedReleaseManifest -and
+        @($cliEntries | Where-Object { $_.sourceDirty -ne $false }).Count -ne 0) {
+        throw 'One or more CLI assets do not have clean source provenance.'
+    }
 }
 
 [pscustomobject] @{

--- a/Build/Test-ReleaseConfiguration.ps1
+++ b/Build/Test-ReleaseConfiguration.ps1
@@ -15,10 +15,43 @@ if ([string] $release.GitHub.TokenEnvName -ne 'GITHUB_TOKEN' -or
     -not [string]::IsNullOrWhiteSpace([string] $release.GitHub.TokenFilePath)) {
     throw 'The unified GitHub release must use GITHUB_TOKEN without a machine-specific token path.'
 }
+if ($null -eq $release.Tools -or $release.GitHub.Publish -ne $true) {
+    throw 'The full release must include CLI tools and the unified GitHub release.'
+}
+if (@($release.Module.ArtifactPaths | Where-Object { $_ -like '*EventViewerX.Cli.*.nupkg' }).Count -ne 0) {
+    throw 'The full release must not publish the deferred EventViewerX.Cli .NET tool package.'
+}
+
+$moduleRelease = Get-Content -LiteralPath `
+    (Join-Path $RepositoryRoot 'Build\release.module.json') -Raw |
+    ConvertFrom-Json
+if ($null -ne $moduleRelease.Tools -or $null -ne $moduleRelease.GitHub) {
+    throw 'The module release must not include CLI tools or a unified GitHub release.'
+}
+if ($moduleRelease.Module.IncludesPackages -ne $true -or
+    [string] $moduleRelease.Module.ConfigPath -ne 'Build/module.json') {
+    throw 'The module release must include the canonical EventViewerX package configuration.'
+}
+if (@($moduleRelease.Module.ArtifactPaths | Where-Object { $_ -like '*EventViewerX.Cli.*.nupkg' }).Count -ne 0) {
+    throw 'The module release must not publish the deferred EventViewerX.Cli .NET tool package.'
+}
+[array] $fullModuleAssets = @($release.Module.ArtifactPaths | Sort-Object)
+[array] $moduleOnlyAssets = @($moduleRelease.Module.ArtifactPaths | Sort-Object)
+if (($fullModuleAssets -join "`n") -cne ($moduleOnlyAssets -join "`n")) {
+    throw 'The full and module-only release profiles must use the same package/module artifact set.'
+}
+[array] $moduleReleaseValidations = @($moduleRelease.Validation.AfterStaging)
+if ($moduleReleaseValidations.Count -ne 1 -or
+    [string] $moduleReleaseValidations[0].FilePath -ne 'Test-ModuleReleaseReady.ps1') {
+    throw 'The module release must validate its exact staged package and module artifacts.'
+}
 
 $projectBuild = Get-Content -LiteralPath `
     (Join-Path $RepositoryRoot 'Sources\Build\project.build.json') -Raw |
     ConvertFrom-Json
+if ($null -ne $projectBuild.ExpectedVersionMap.PSObject.Properties['EventViewerX.Cli']) {
+    throw 'The EventViewerX.Cli .NET tool package must remain outside the library/module release.'
+}
 if ([string] $projectBuild.PublishApiKeyEnvName -ne 'NUGET_API_KEY' -or
     -not [string]::IsNullOrWhiteSpace([string] $projectBuild.PublishApiKeyFilePath)) {
     throw 'NuGet publication must use NUGET_API_KEY without a machine-specific API-key path.'
@@ -56,4 +89,7 @@ if (@($legacyGitHubSegments | Where-Object {
     NuGetCredential = 'NUGET_API_KEY'
     GitHubCredential = 'GITHUB_TOKEN'
     PowerShellGalleryCredential = $galleryKeyPath
+    FullReleaseIncludesCli = $true
+    ModuleReleaseIncludesCli = $false
+    CliNuGetPackageIncluded = $false
 }

--- a/Build/Test-ReleaseGuards.ps1
+++ b/Build/Test-ReleaseGuards.ps1
@@ -6,11 +6,35 @@ $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $buildModulePath = Join-Path $PSScriptRoot 'Build-Module.ps1'
 $buildReleasePath = Join-Path $PSScriptRoot 'Build-Release.ps1'
 
+$unsupportedPublishArguments = @(
+    @{ PreReleaseTag = 'preview1' }
+    @{ Configuration = 'Debug' }
+    @{ NoDotnetBuild = $true }
+    @{ StagingPath = 'Artefacts\Existing' }
+    @{ ReuseStaging = $true }
+    @{ IncludeProjectPackages = $false }
+    @{ IncludeModulePublishing = $false }
+    @{ PowerForgeUnifiedGitHubRelease = $true }
+    @{ PowerForgeReleaseStage = $true }
+)
+foreach ($arguments in $unsupportedPublishArguments) {
+    [string] $parameterName = @($arguments.Keys)[0]
+    try {
+        & $buildModulePath -RunMode Publish -ModuleVersion '4.0.0' `
+            -SignModule:$false @arguments
+        throw "Build-Module.ps1 unexpectedly accepted $parameterName for publication."
+    } catch {
+        if ($_.Exception.Message -notlike "*does not support:*$parameterName*") {
+            throw
+        }
+    }
+}
+
 try {
-    & $buildModulePath -RunMode Publish -SignModule:$false
-    throw 'Build-Module.ps1 unexpectedly accepted direct publication.'
+    & $buildModulePath -RunMode Publish -ModuleVersion '4.0.0' -SignModule:$false
+    throw 'Build-Module.ps1 unexpectedly accepted publication without an exact commit.'
 } catch {
-    if ($_.Exception.Message -notlike 'Direct module publication is disabled.*') {
+    if ($_.Exception.Message -notlike 'ExpectedCommit is required for a public release.*') {
         throw
     }
 }
@@ -25,7 +49,7 @@ try {
     Set-Content -LiteralPath $markerPath -Value 'release guard validation'
     try {
         & $buildReleasePath -RunMode Publish -Version '4.0.0' `
-            -SignModule:$false -ExpectedCommit $actualCommit `
+            -SignModule:$false -SkipCli -ExpectedCommit $actualCommit `
             -Confirmation "publish:4.0.0:$actualCommit"
         throw 'Build-Release.ps1 unexpectedly accepted an untracked file.'
     } catch {
@@ -41,6 +65,7 @@ try {
 }
 
 [pscustomobject] @{
-    DirectModulePublishBlocked = $true
+    UnsupportedPublishParametersBlocked = $unsupportedPublishArguments.Count
+    UnguardedModulePublishBlocked = $true
     UntrackedFileBlocked = $true
 }

--- a/Build/Test-ReleasePlans.ps1
+++ b/Build/Test-ReleasePlans.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$buildAllPath = Join-Path $PSScriptRoot 'Build-All.ps1'
+
+$modulePlan = & $buildAllPath -RunMode Plan -SkipCli -Version '4.0.0' `
+    -SignModule:$false
+if ($null -eq $modulePlan -or -not $modulePlan.Success) {
+    throw 'The module/package release plan did not succeed.'
+}
+if ($null -eq $modulePlan.ModulePlan -or
+    $modulePlan.ModulePlan.IncludesProjectPackages -ne $true) {
+    throw 'The module/package release plan must include EventViewerX NuGet packages.'
+}
+if (@($modulePlan.ModuleAssets | Where-Object { $_ -like '*EventViewerX.Cli.*.nupkg' }).Count -ne 0) {
+    throw 'The module/package release plan must exclude the EventViewerX.Cli .NET tool package.'
+}
+if ($null -ne $modulePlan.DotNetToolPlan -or
+    $modulePlan.ModulePlan.UnifiedGitHubRelease -eq $true) {
+    throw 'The module/package release plan must exclude standalone CLI and unified GitHub publication.'
+}
+
+$fullPlan = & $buildAllPath -RunMode Plan -Version '4.0.0' -SignModule:$false
+if ($null -eq $fullPlan -or -not $fullPlan.Success) {
+    throw 'The full release plan did not succeed.'
+}
+if ($null -eq $fullPlan.DotNetToolPlan -or
+    @($fullPlan.DotNetToolPlan.Targets.Combinations).Count -ne 12) {
+    throw 'The full release plan must include all 12 standalone CLI artifacts.'
+}
+if ($fullPlan.ModulePlan.UnifiedGitHubRelease -ne $true) {
+    throw 'The full release plan must retain unified GitHub publication.'
+}
+
+[pscustomobject] @{
+    ModulePackages = $modulePlan.ModulePlan.IncludesProjectPackages
+    ModuleCliAssets = 0
+    FullCliAssets = @($fullPlan.DotNetToolPlan.Targets.Combinations).Count
+    FullUnifiedGitHubRelease = $fullPlan.ModulePlan.UnifiedGitHubRelease
+}

--- a/Build/Test-ReleaseReady.ps1
+++ b/Build/Test-ReleaseReady.ps1
@@ -3,7 +3,9 @@ param(
     [ValidatePattern('^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$')]
     [string] $Version,
 
-    [string] $CliManifestPath
+    [string] $CliManifestPath,
+
+    [switch] $SkipCliArtifacts
 )
 
 $ErrorActionPreference = 'Stop'
@@ -31,7 +33,8 @@ $moduleRoot = $null
 $packageRoot = $null
 $moduleValidationRoot = $null
 if ($null -ne $context) {
-    if ([string]::IsNullOrWhiteSpace($CliManifestPath) -and
+    if (-not $SkipCliArtifacts -and
+        [string]::IsNullOrWhiteSpace($CliManifestPath) -and
         -not [string]::IsNullOrWhiteSpace([string] $context.ReleaseManifestPath)) {
         $CliManifestPath = [string] $context.ReleaseManifestPath
     }
@@ -43,13 +46,13 @@ if ($null -ne $context) {
         throw "Expected one staged PSEventViewer $Version archive, found $($modulePackages.Count)."
     }
 
-    [array] $cliPackages = @($context.StagedAssets | Where-Object {
-        [System.IO.Path]::GetFileName([string] $_) -ieq "EventViewerX.Cli.$Version.nupkg"
+    [array] $eventViewerPackages = @($context.StagedAssets | Where-Object {
+        [System.IO.Path]::GetFileName([string] $_) -ieq "EventViewerX.$Version.nupkg"
     })
-    if ($cliPackages.Count -ne 1) {
-        throw "Expected one staged EventViewerX.Cli $Version package, found $($cliPackages.Count)."
+    if ($eventViewerPackages.Count -ne 1) {
+        throw "Expected one staged EventViewerX $Version package, found $($eventViewerPackages.Count)."
     }
-    $packageRoot = Split-Path -Parent ([string] $cliPackages[0])
+    $packageRoot = Split-Path -Parent ([string] $eventViewerPackages[0])
 
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     $validationRoot = Join-Path $repositoryRoot 'Artefacts\Validation'
@@ -75,12 +78,6 @@ try {
     }
     & (Join-Path $PSScriptRoot 'Test-ModuleRuntime.ps1') @moduleRuntimeSplat
 
-    $cliPackageSplat = @{ Version = $Version }
-    if (-not [string]::IsNullOrWhiteSpace($packageRoot)) {
-        $cliPackageSplat.PackageRoot = $packageRoot
-    }
-    & (Join-Path $PSScriptRoot 'Test-CliPackage.ps1') @cliPackageSplat
-
     $architectureSplat = @{ RepositoryRoot = $repositoryRoot }
     if (-not [string]::IsNullOrWhiteSpace($packageRoot)) {
         $architectureSplat.PackageRoot = $packageRoot
@@ -90,6 +87,9 @@ try {
     }
     if (-not [string]::IsNullOrWhiteSpace($CliManifestPath)) {
         $architectureSplat.CliManifestPath = $CliManifestPath
+    }
+    if ($SkipCliArtifacts) {
+        $architectureSplat.SkipCliArtifacts = $true
     }
     & (Join-Path $PSScriptRoot 'Test-ReleaseArchitecture.ps1') @architectureSplat
 } finally {

--- a/Build/release.json
+++ b/Build/release.json
@@ -12,7 +12,6 @@
     "ArtifactPaths": [
       "Artefacts/Packed/PSEventViewer.v{ModuleVersionWithPreRelease}.zip",
       "Artefacts/ProjectBuild/packages/EventViewerX.{ModuleVersionWithPreRelease}.nupkg",
-      "Artefacts/ProjectBuild/packages/EventViewerX.Cli.{ModuleVersionWithPreRelease}.nupkg",
       "Artefacts/ProjectBuild/packages/EventViewerX.Detection.{ModuleVersionWithPreRelease}.nupkg",
       "Artefacts/ProjectBuild/packages/EventViewerX.Evtx.{ModuleVersionWithPreRelease}.nupkg",
       "Artefacts/ProjectBuild/packages/EventViewerX.Reporting.{ModuleVersionWithPreRelease}.nupkg",

--- a/Build/release.module.json
+++ b/Build/release.module.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.release.schema.json",
+  "SchemaVersion": 1,
+  "Module": {
+    "RepositoryRoot": "..",
+    "ModuleName": "PSEventViewer",
+    "ConfigPath": "Build/module.json",
+    "IncludesPackages": true,
+    "ModuleVersion": "4.0.X",
+    "SignModule": true,
+    "TimeoutSeconds": 7200,
+    "ArtifactPaths": [
+      "Artefacts/Packed/PSEventViewer.v{ModuleVersionWithPreRelease}.zip",
+      "Artefacts/ProjectBuild/packages/EventViewerX.{ModuleVersionWithPreRelease}.nupkg",
+      "Artefacts/ProjectBuild/packages/EventViewerX.Detection.{ModuleVersionWithPreRelease}.nupkg",
+      "Artefacts/ProjectBuild/packages/EventViewerX.Evtx.{ModuleVersionWithPreRelease}.nupkg",
+      "Artefacts/ProjectBuild/packages/EventViewerX.Reporting.{ModuleVersionWithPreRelease}.nupkg",
+      "Artefacts/ProjectBuild/packages/EventViewerX.Storage.{ModuleVersionWithPreRelease}.nupkg"
+    ]
+  },
+  "Outputs": {
+    "Staging": {
+      "RootPath": "../Artefacts/UploadReady/ModuleRelease",
+      "ModulesPath": "module",
+      "PackagesPath": "nuget",
+      "PortablePath": "portable",
+      "InstallerPath": "installer",
+      "StorePath": "store",
+      "ToolsPath": "cli",
+      "MetadataPath": "metadata",
+      "OtherPath": "assets"
+    }
+  },
+  "Validation": {
+    "AfterStaging": [
+      {
+        "Name": "Validate EventViewerX NuGet and PSEventViewer release artifacts",
+        "FilePath": "Test-ModuleReleaseReady.ps1",
+        "WorkingDirectory": "..",
+        "TimeoutSeconds": 1800
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1138,22 +1138,29 @@ rejects a 32-bit Desktop host before loading it.
 
 ## Development and release
 
-The root build wrapper delegates versioning, library packaging, module
-packaging, signing, artifacts, NuGet, PowerShell Gallery, and GitHub release
-coordination to PSPublishModule/PowerForge. EventViewerX and PSEventViewer are
-built and released from one version source and validated as packed artifacts.
+The build wrappers delegate versioning, library packaging, module packaging,
+signing, artifacts, NuGet, PowerShell Gallery, and GitHub release coordination
+to PSPublishModule/PowerForge. EventViewerX and PSEventViewer use one version
+source and are validated as packed artifacts. The package/module release is
+independent from the standalone CLI archives.
 
 ```powershell
-# Inspect the complete module, NuGet, and CLI release without producing assets.
-.\Build\Build-Release.ps1 -RunMode Plan -Version 4.0.0 -SignModule:$false
+# Inspect the EventViewerX NuGet and PSEventViewer release without producing assets.
+.\Build\Build-All.ps1 -RunMode Plan -SkipCli -Version 4.0.0 -SignModule:$false
 
-# Produce and validate one unsigned release candidate. Nothing is published.
-.\Build\Build-Release.ps1 -RunMode Build -Version 4.0.0 -SignModule:$false
+# Produce and validate those packages without publishing standalone CLI archives.
+.\Build\Build-All.ps1 -RunMode Build -SkipCli -Version 4.0.0 -SignModule:$false
 
-# Publication is a separate, guarded operator action after the candidate settles.
+# Publish EventViewerX library packages to NuGet and PSEventViewer to PowerShell Gallery.
 $commit = git rev-parse HEAD
-.\Build\Build-Release.ps1 -RunMode Publish -Version 4.0.0 `
-    -ExpectedCommit $commit -Confirmation "publish:4.0.0:$commit"
+.\Build\Build-Module.ps1 -RunMode Publish -ModuleVersion 4.0.0 `
+    -ExpectedCommit $commit -PublishConfirmation "publish:4.0.0:$commit"
+
+# Build the standalone CLI archives locally. This command does not upload them.
+.\Build\Build-Cli.ps1 -RunMode Build
+
+# Plan the complete package, module, CLI, and unified GitHub release.
+.\Build\Build-All.ps1 -RunMode Plan -Version 4.0.0 -SignModule:$false
 ```
 
 Browse [the event query benchmark contract](Benchmarks/EventLogParsing/README.md),

--- a/Sources/Build/project.build.json
+++ b/Sources/Build/project.build.json
@@ -4,7 +4,6 @@
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
     "EventViewerX": "4.0.X",
-    "EventViewerX.Cli": "4.0.X",
     "EventViewerX.Detection": "4.0.X",
     "EventViewerX.Evtx": "4.0.X",
     "EventViewerX.Reporting": "4.0.X",


### PR DESCRIPTION
## Summary

- add a dedicated package/module release profile for PSEventViewer and the five EventViewerX library packages
- keep the CLI tool package and standalone CLI archives out of the package/module lane
- retain an explicit full release plan for RID-specific CLI archives and the unified GitHub release
- make `SkipCli` and `SkipInstall` consistent across the build entry points
- fail closed when full-release-only controls are passed to guarded module publication

## Release behavior

`Build-Module.ps1 -RunMode Publish` now routes through the guarded module profile. It requires an exact commit and explicit confirmation, and publishes only the PSEventViewer module plus the EventViewerX, Detection, Evtx, Reporting, and Storage NuGet packages.

`Build-All.ps1 -RunMode Plan` describes the complete release, including the 12 RID-specific standalone CLI archives and unified GitHub release. The `EventViewerX.Cli` NuGet tool is no longer part of package publication.

## Validation

- release configuration, publication guard, and release-plan checks pass in Windows PowerShell 5.1
- an unsigned module-lane build produced exactly the module archive and five library NuGet packages, with no CLI artifacts
- PowerShell parsing and `git diff --check` pass

No signed artifacts or remote publication were performed.
